### PR TITLE
trim properties. Scheduled empty db check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.3.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.3.1.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <wiremock.version>2.28.1</wiremock.version>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -67,6 +67,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/com/redhat/labs/lodestar/participants/rest/client/GitlabApiClient.java
+++ b/src/main/java/com/redhat/labs/lodestar/participants/rest/client/GitlabApiClient.java
@@ -58,6 +58,11 @@ public class GitlabApiClient {
 
     @PostConstruct
     void setupGitlabClient() {
+        gitUrl = gitUrl.trim();
+        pat = pat.trim();
+
+        LOGGER.info("Using git {}", gitUrl);
+
         gitlabApi = new GitLabApi(gitUrl, pat);
         gitlabApi.enableRequestResponseLogging();
     }

--- a/src/main/java/com/redhat/labs/lodestar/participants/service/ParticipantService.java
+++ b/src/main/java/com/redhat/labs/lodestar/participants/service/ParticipantService.java
@@ -16,6 +16,7 @@ import javax.transaction.Transactional;
 
 import com.redhat.labs.lodestar.participants.model.*;
 import com.redhat.labs.lodestar.participants.rest.client.GitlabApiClient;
+import io.quarkus.scheduler.Scheduled;
 import io.quarkus.vertx.ConsumeEvent;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -49,7 +50,8 @@ public class ParticipantService {
     @ConfigProperty(name = "commit.message.prefix")
     String commitMessagePrefix;
 
-    void onStart(@Observes StartupEvent ev) {
+    @Scheduled(every = "2m")
+    void checkDBPopulation() {
         long count = participantRepository.count();
         LOGGER.debug("There are {} participant in the participant db.", count);
 

--- a/src/test/java/com/redhat/labs/lodestar/participants/service/ParticipantServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/participants/service/ParticipantServiceTest.java
@@ -96,6 +96,16 @@ class ParticipantServiceTest {
         
         assertEquals(6, participantService.getParticipantCount());
     }
+
+    @Test
+    void testCheckDBPopTwice() {
+        participantService.purge();
+        participantService.checkDBPopulation();
+        assertEquals(6, participantService.getParticipantCount());
+
+        participantService.checkDBPopulation();
+        assertEquals(6, participantService.getParticipantCount());
+    }
     
     @Test
     void testReloadEngagementFailure() {


### PR DESCRIPTION
- trims properties on start
- checks db for emptiness every 2 mins instead of only at start up